### PR TITLE
Remove obsolete bash set-env

### DIFF
--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import json
-import sys
 import agent
 import os
 

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -1,33 +1,28 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2021 Nethesis S.r.l.
-# http://www.nethesis.it - nethserver@nethesis.it
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# This script is part of NethServer.
-#
-# NethServer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License,
-# or any later version.
-#
-# NethServer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NethServer.  If not, see COPYING.
-#
-set -e
 
-exec 1>&2 # Send any output to stderr, to not alter the action response protocol
+import json
+import sys
+import agent
+import os
 
-cat >&${AGENT_COMFD} <<EOF
-set-env LOKI_ADDR $(REDIS_USER=default redis-exec HGET node/${NODE_ID}/vpn ip_address)
-set-env LOKI_API_AUTH_USERNAME loki
-set-env LOKI_API_AUTH_PASSWORD $(uuidgen)
-set-env LOKI_LOGS_INGRESS_TOKEN $(uuidgen)
-set-env LOKI_HTTP_PORT ${TCP_PORT}
-dump-env
-EOF
+def genuuid():
+    uuid =  os.popen("uuidgen")
+    return uuid.read()
+
+node_id = os.environ['NODE_ID']
+port = os.environ['TCP_PORT']
+
+rdb = agent.redis_connect()
+rkey = f'node/{node_id}/vpn'
+ip_address = rdb.hget(rkey, 'ip_address')
+
+agent.set_env('LOKI_ADDR', ip_address)
+agent.set_env('LOKI_API_AUTH_USERNAME', 'loki')
+agent.set_env('LOKI_API_AUTH_PASSWORD', genuuid())
+agent.set_env('LOKI_LOGS_INGRESS_TOKEN', genuuid())
+agent.set_env('LOKI_HTTP_PORT', port)


### PR DESCRIPTION
following https://trello.com/c/jBkc6Qwt/365-core-p1-agent-set-env-deprecation

- Remove the deprecated set-env 
- Sync the agent Redis */environment key on every action run, no matter for the exit code