### PR TITLE
Limit log query result size

### DIFF
--- a/imageroot/bin/cloud-log-manager-forwarder
+++ b/imageroot/bin/cloud-log-manager-forwarder
@@ -76,7 +76,7 @@ logs_list = []
 while True:
     try:
         # LogCLI command
-        logcli_command = ["logcli", "query", "--limit", "0", "--forward", "--timezone", "UTC", "--from", last_timestamp, "--no-labels", "-q", "-o", "jsonl",
+        logcli_command = ["logcli", "query", "--limit", "2000", "--forward", "--timezone", "UTC", "--from", last_timestamp, "--no-labels", "-q", "-o", "jsonl",
                           '{node_id=~".+"} | json identifier="SYSLOG_IDENTIFIER", priority="PRIORITY", message="MESSAGE" | line_format "<{{.priority}}> [{{.node_id}}:{{.module_id}}:{{.identifier}}]: {{.message}}"']
         response = subprocess.run(logcli_command, capture_output=True, text=True, timeout=300)
 


### PR DESCRIPTION
Set a max number of records returned by Loki to avoid leaking memory.

- After applying the limit, RAM usage seems lower.
- The timestamp file `cloud_log_manager_last_timestamp` is written frequently. With limit=0, the file was never written.

Refs https://github.com/NethServer/dev/issues/6978