### PR TITLE
Add User-Selectable Filters for Cloud Log Manager and Syslog Exporters

### DIFF
--- a/imageroot/actions/get-configuration/10get
+++ b/imageroot/actions/get-configuration/10get
@@ -32,6 +32,7 @@ match clm_status.stdout.strip():
 
 cloud_log_manager["address"] = os.getenv('CLOUD_LOG_MANAGER_ADDRESS', '')
 cloud_log_manager["tenant"] = os.getenv('CLOUD_LOG_MANAGER_TENANT', '')
+cloud_log_manager["filter"] = os.getenv('CLOUD_LOG_MANAGER_FILTER', '')
 
 try: 
     with open("./cloud_log_manager_last_timestamp", "r") as clm_file:
@@ -55,6 +56,7 @@ match syslog_status.stdout.strip():
 syslog["address"] = os.getenv('SYSLOG_ADDRESS', '')
 syslog["port"] = os.getenv('SYSLOG_PORT', '')
 syslog["protocol"] = os.getenv('SYSLOG_PROTOCOL', '')
+syslog["filter"] = os.getenv('SYSLOG_FILTER', '')
 syslog["format"] = os.getenv('SYSLOG_FORMAT', '')
 
 try:

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -52,6 +52,10 @@
                 "cluster_id": {
                     "type": "string",
                     "description": "Key that identify cluster on Cloud Log Manager."
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "Log filter type."
                 }
             }
 
@@ -86,6 +90,10 @@
                 "last_timestamp": {
                     "type": "string",
                     "description": "Timestamp of the last log sent."
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "Log filter type."
                 }
             }
         }

--- a/imageroot/actions/set-clm-forwarder/10set
+++ b/imageroot/actions/set-clm-forwarder/10set
@@ -6,10 +6,8 @@
 #
 
 import subprocess
-import hashlib
 import agent
 import json
-import uuid
 import sys
 
 request = json.load(sys.stdin)
@@ -24,6 +22,7 @@ if not bool(subscription):
 if (request['active']):
     agent.set_env('CLOUD_LOG_MANAGER_ADDRESS', f"{request['address']}")
     agent.set_env('CLOUD_LOG_MANAGER_TENANT', f"{request['tenant']}")
+    agent.set_env('CLOUD_LOG_MANAGER_FILTER', f"{request['filter']}")
 
     if 'start_time' in request and request['start_time'] != '':
         agent.set_env('CLOUD_LOG_MANAGER_START_TIME', f"{request['start_time']}")
@@ -38,6 +37,7 @@ else:
     agent.unset_env('CLOUD_LOG_MANAGER_START_TIME')
     agent.unset_env('CLOUD_LOG_MANAGER_ADDRESS')
     agent.unset_env('CLOUD_LOG_MANAGER_TENANT')
+    agent.unset_env('CLOUD_LOG_MANAGER_FILTER')
 
     action = 'disable'
 

--- a/imageroot/actions/set-clm-forwarder/validate-input.json
+++ b/imageroot/actions/set-clm-forwarder/validate-input.json
@@ -20,6 +20,10 @@
         "start_time": {
             "type": "string",
             "description": "Log forwarding start time."
+        },
+        "filter": {
+            "type": "string",
+            "description": "Log filter type"
         }
     },
     "oneOf": [

--- a/imageroot/actions/set-syslog-forwarder/10set
+++ b/imageroot/actions/set-syslog-forwarder/10set
@@ -20,6 +20,7 @@ if (request['active']):
     agent.set_env('SYSLOG_PORT', f"{request['port']}")
     agent.set_env('SYSLOG_PROTOCOL', f"{request['protocol']}")
     agent.set_env('SYSLOG_FORMAT', f"{request['format']}")
+    agent.set_env('SYSLOG_FILTER', f"{request['filter']}")
 
     if 'start_time' in request and request['start_time'] != '':
         agent.set_env('SYSLOG_START_TIME', f"{request['start_time']}")
@@ -36,6 +37,7 @@ else:
     agent.unset_env('SYSLOG_PROTOCOL')
     agent.unset_env('SYSLOG_FORMAT')
     agent.unset_env('SYSLOG_START_TIME')
+    agent.unset_env('SYSLOG_FILTER')
 
     action = 'disable'
 

--- a/imageroot/actions/set-syslog-forwarder/validate-input.json
+++ b/imageroot/actions/set-syslog-forwarder/validate-input.json
@@ -28,6 +28,10 @@
         "start_time": {
             "type": "string",
             "description": "Log forwarding start time."
+        },
+        "filter": {
+            "type": "string",
+            "description": "Log filter type"
         }
     },
     "oneOf": [

--- a/imageroot/bin/cloud-log-manager-forwarder
+++ b/imageroot/bin/cloud-log-manager-forwarder
@@ -25,6 +25,7 @@ try:
     START_TIME = os.environ.get('CLOUD_LOG_MANAGER_START_TIME', '')
     ADDRESS = os.environ.get('CLOUD_LOG_MANAGER_ADDRESS', 'https://nar.nethesis.it')
     TENANT = os.environ.get('CLOUD_LOG_MANAGER_TENANT')
+    FILTER = os.environ.get('CLOUD_LOG_MANAGER_FILTER')
 
     os.environ['LOKI_ADDR'] = f"http://127.0.0.1:{os.environ['LOKI_HTTP_PORT']}"
     os.environ['LOKI_USERNAME'] = os.environ['LOKI_API_AUTH_USERNAME']
@@ -76,7 +77,7 @@ logs_list = []
 while True:
     try:
         # LogCLI command
-        logcli_command = ["logcli", "query", "--limit", "2000", "--forward", "--timezone", "UTC", "--from", last_timestamp, "--no-labels", "-q", "-o", "jsonl",
+        logcli_command = ["logcli", "query", "--limit", "2000", "--forward", "--timezone", "UTC", "--from", last_timestamp, "-q", "-o", "jsonl",
                           '{node_id=~".+"} | json identifier="SYSLOG_IDENTIFIER", priority="PRIORITY", message="MESSAGE" | line_format "<{{.priority}}> [{{.node_id}}:{{.module_id}}:{{.identifier}}]: {{.message}}"']
         response = subprocess.run(logcli_command, capture_output=True, text=True, timeout=300)
 
@@ -87,6 +88,11 @@ while True:
                 # Log if stdout contains something new
                 if log:
                     json_object = json.loads(log)
+                    labels = json_object["labels"]
+
+                    if FILTER != None and FILTER not in labels:
+                        continue
+
                     line = str(json_object["line"])
 
                     if line[line.find(":")+1:line.find(":", line.find(":")+1)] != '':

--- a/imageroot/bin/syslog-forwarder
+++ b/imageroot/bin/syslog-forwarder
@@ -23,6 +23,7 @@ try:
     PROTOCOL = os.environ.get('SYSLOG_PROTOCOL', 'udp')
     FORMAT = os.environ.get('SYSLOG_FORMAT', 'rfc3164')
     START_TIME = os.environ.get('SYSLOG_START_TIME', '')
+    FILTER = os.environ.get('SYSLOG_FILTER')
 
     os.environ['LOKI_ADDR'] = f"http://127.0.0.1:{os.environ['LOKI_HTTP_PORT']}"
     os.environ['LOKI_USERNAME'] = os.environ['LOKI_API_AUTH_USERNAME']
@@ -73,13 +74,18 @@ while True:
     try:
         # LogCLI command
         logcli_command = ["logcli", "query", "--limit", "0", "--forward", "--timezone", "UTC", 
-                          "--from", last_timestamp, "--no-labels", "-q", "-o", "jsonl", '{node_id=~".+"}']
+                          "--from", last_timestamp, "-q", "-o", "jsonl", '{node_id=~".+"}']
         response = subprocess.run(logcli_command, capture_output=True, text=True)
         for log in response.stdout.splitlines():
             try:
                 # Log if stdout contains something new
                 if log:
                     json_object = json.loads(log)
+                    labels = json_object["labels"]
+
+                    if FILTER != None and FILTER not in labels:
+                        continue
+
                     line = json.loads(json_object["line"])
 
                     # Set facility value


### PR DESCRIPTION
This PR introduces the ability for users to apply filters when activating the forwarders for Cloud Log Manager and Syslog exporters. With this enhancement, users can now select specific log categories or types to be forwarded during the setup phase, providing more control over the log data being exported.

**Key Changes**:

- Added a new filtering option in the Cloud Log Manager and Syslog exporter configuration screens.
- Users can now choose from predefined filter options during the forwarder activation process.
- Improved forwarder setup experience, giving users the flexibility to manage which logs are exported.

[NethServer/dev#7061](https://github.com/NethServer/dev/issues/7061)