### PR TITLE
Set 'security' filter as default for CLM

### DIFF
--- a/imageroot/actions/set-clm-forwarder/validate-input.json
+++ b/imageroot/actions/set-clm-forwarder/validate-input.json
@@ -34,7 +34,6 @@
             "required": [
                 "active",
                 "address",
-                "filter",
                 "tenant"
             ]
         },

--- a/imageroot/bin/cloud-log-manager-forwarder
+++ b/imageroot/bin/cloud-log-manager-forwarder
@@ -25,7 +25,7 @@ try:
     START_TIME = os.environ.get('CLOUD_LOG_MANAGER_START_TIME', '')
     ADDRESS = os.environ.get('CLOUD_LOG_MANAGER_ADDRESS', 'https://nar.nethesis.it')
     TENANT = os.environ.get('CLOUD_LOG_MANAGER_TENANT')
-    FILTER = os.environ.get('CLOUD_LOG_MANAGER_FILTER')
+    FILTER = os.environ.get('CLOUD_LOG_MANAGER_FILTER', 'security')
 
     os.environ['LOKI_ADDR'] = f"http://127.0.0.1:{os.environ['LOKI_HTTP_PORT']}"
     os.environ['LOKI_USERNAME'] = os.environ['LOKI_API_AUTH_USERNAME']


### PR DESCRIPTION
Removed 'filter' field from API requirements and cloud log manager use 'security' category filter as default.
It is still possible to set a different category filter for cloud log manager but only using command line.

[NethServer/dev#7061](https://github.com/NethServer/dev/issues/7061)