### PR TITLE
Fix CLM configuration error

### DIFF
--- a/imageroot/actions/set-clm-forwarder/10set
+++ b/imageroot/actions/set-clm-forwarder/10set
@@ -22,7 +22,8 @@ if not bool(subscription):
 if (request['active']):
     agent.set_env('CLOUD_LOG_MANAGER_ADDRESS', f"{request['address']}")
     agent.set_env('CLOUD_LOG_MANAGER_TENANT', f"{request['tenant']}")
-    agent.set_env('CLOUD_LOG_MANAGER_FILTER', f"{request['filter']}")
+    if 'filter' in request:
+        agent.set_env('CLOUD_LOG_MANAGER_FILTER', request['filter'])
 
     if 'start_time' in request and request['start_time'] != '':
         agent.set_env('CLOUD_LOG_MANAGER_START_TIME', f"{request['start_time']}")


### PR DESCRIPTION
The "filter" field is optional, ensure it is present before setting the environment variable.

```text
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]: task/module/loki1/cb194da5-28c4-47b5-9df8-317b7b6fa786: set-clm-forwarder/10set is starting
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]: Traceback (most recent call last):
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]:   File "/home/loki1/.config/actions/set-clm-forwarder/10set", line 25, in <module>
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]:     agent.set_env('CLOUD_LOG_MANAGER_FILTER', f"{request['filter']}")
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]:                                                  ~~~~~~~^^^^^^^^^^
Nov 04 11:12:08 rl1.dp.nethserver.net agent@loki1[34817]: KeyError: 'filter'
Nov 04 11:12:09 rl1.dp.nethserver.net agent@loki1[34817]: task/module/loki1/cb194da5-28c4-47b5-9df8-317b7b6fa786: action "set-clm-forwarder" status is "aborted" (1) at step 10set
```

Refs NethServer/dev#7061