### PR TITLE
chore: bump traefik and loki

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -10,7 +10,7 @@ container=$(buildah from scratch)
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config --entrypoint=/ \
-	--label="org.nethserver.images=docker.io/traefik:v2.11.13 docker.io/grafana/loki:2.9.11" \
+	--label="org.nethserver.images=docker.io/traefik:v3.3.4 docker.io/grafana/loki:3.4.2" \
 	--label="org.nethserver.min-core=3.2.0-0" \
 	--label="org.nethserver.tcp-ports-demand=1" \
     --label='org.nethserver.flags=core_module' \

--- a/imageroot/loki-config.yaml
+++ b/imageroot/loki-config.yaml
@@ -15,7 +15,6 @@ ingester:
   max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
   chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
   chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
-  max_transfer_retries: 0     # Chunk transfers disabled
   wal:
     dir: "/tmp/wal"
 
@@ -41,13 +40,11 @@ storage_config:
     active_index_directory: /loki/boltdb-shipper-active
     cache_location: /loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
-    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
 
 compactor:
   working_directory: /loki/boltdb-shipper-compactor
-  shared_store: filesystem
   retention_enabled: true
   retention_delete_delay: 30m
   delete_request_store: filesystem
@@ -56,9 +53,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   retention_period: ${LOKI_RETENTION_PERIOD:-365}d
-
-chunk_store_config:
-  max_look_back_period: 0s
 
 ruler:
   storage:

--- a/imageroot/loki-config.yaml
+++ b/imageroot/loki-config.yaml
@@ -28,6 +28,13 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2025-03-20
+      store: tsdb
+      object_store: filesystem
+      schema: v12
+      index:
+        prefix: tsdb_index_
+        period: 24h
 
 storage_config:
   boltdb_shipper:
@@ -64,3 +71,10 @@ ruler:
     kvstore:
       store: inmemory
   enable_api: true
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100

--- a/imageroot/scripts/expandconfig-traefik
+++ b/imageroot/scripts/expandconfig-traefik
@@ -23,6 +23,8 @@
 set -e
 
 cat >traefik.yaml <<EOF
+core:
+  defaultRuleSyntax: v2
 http:
   routers:
     loki-log-ingress:


### PR DESCRIPTION
Both software are bumped to a new major release.

To test the update:
```
api-cli run update-module --data '{"module_url": "ghcr.io/nethserver/loki:issue7273", "instances": ["loki1"], "force": true}'
```