### PR TITLE
Upgrade to Loki v3

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -10,7 +10,7 @@ container=$(buildah from scratch)
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config --entrypoint=/ \
-	--label="org.nethserver.images=docker.io/traefik:v2.11.13 docker.io/grafana/loki:3.4.0" \
+	--label="org.nethserver.images=docker.io/traefik:v3.3.5 docker.io/grafana/loki:3.4.0" \
 	--label="org.nethserver.min-core=3.2.0-0" \
 	--label="org.nethserver.tcp-ports-demand=1" \
     --label='org.nethserver.flags=core_module' \

--- a/build-images.sh
+++ b/build-images.sh
@@ -10,7 +10,7 @@ container=$(buildah from scratch)
 buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config --entrypoint=/ \
-	--label="org.nethserver.images=docker.io/traefik:v2.11.13 docker.io/grafana/loki:2.9.11" \
+	--label="org.nethserver.images=docker.io/traefik:v2.11.13 docker.io/grafana/loki:3.4.0" \
 	--label="org.nethserver.min-core=3.2.0-0" \
 	--label="org.nethserver.tcp-ports-demand=1" \
     --label='org.nethserver.flags=core_module' \

--- a/imageroot/actions/create-module/10env
+++ b/imageroot/actions/create-module/10env
@@ -37,3 +37,5 @@ agent.set_env('LOKI_RETENTION_PERIOD', initial_retention)
 agent.set_env('LOKI_ACTIVE_FROM', datetime.datetime.now().astimezone().isoformat())
 agent.set_env('CLOUD_LOG_MANAGER_UUID', clm_uuid)
 agent.set_env('CLOUD_LOG_MANAGER_HOSTNAME', 'cluster-' + clm_uuid[:8])
+agent.set_env('LOKI_V13_SCHEMA_START', '2025-04-01') # this must be a date in the past
+agent.set_env('LOKI_ALLOW_STRUCTURED_METADATA', 'true')

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -8,7 +8,6 @@
 import sys
 import json
 import agent
-import os
 
 request = json.load(sys.stdin)
 
@@ -17,6 +16,8 @@ original_environment = request['environment']
 for evar in [
         "LOKI_RETENTION_PERIOD",
         "LOKI_ACTIVE_FROM",
+        "LOKI_V13_SCHEMA_START",
+        "LOKI_ALLOW_STRUCTURED_METADATA"
         # NOTE: LOKI_ACTIVE_TO is restored by a later step
     ]:
     agent.set_env(evar, original_environment[evar])

--- a/imageroot/loki-config.yaml
+++ b/imageroot/loki-config.yaml
@@ -27,7 +27,7 @@ schema_config:
       index:
         prefix: index_
         period: 24h
-    - from: 2025-05-09
+    - from: ${LOKI_V13_SCHEMA_START}
       store: tsdb
       object_store: filesystem
       schema: v13
@@ -58,7 +58,7 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   retention_period: ${LOKI_RETENTION_PERIOD:-365}d
-  allow_structured_metadata: false # this can be removed after 2025-05-09
+  allow_structured_metadata: ${LOKI_ALLOW_STRUCTURED_METADATA}
   volume_enabled: true
 
 ruler:

--- a/imageroot/loki-config.yaml
+++ b/imageroot/loki-config.yaml
@@ -15,7 +15,6 @@ ingester:
   max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
   chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
   chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
-  max_transfer_retries: 0     # Chunk transfers disabled
   wal:
     dir: "/tmp/wal"
 
@@ -28,19 +27,29 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2025-05-09
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: tsdb_index_
+        path_prefix: tsdb-index/
+        period: 24h
 
 storage_config:
   boltdb_shipper:
     active_index_directory: /loki/boltdb-shipper-active
     cache_location: /loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
-    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-index_cache
+    cache_ttl: 24h
 
 compactor:
   working_directory: /loki/boltdb-shipper-compactor
-  shared_store: filesystem
   retention_enabled: true
   retention_delete_delay: 30m
   delete_request_store: filesystem
@@ -49,9 +58,8 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   retention_period: ${LOKI_RETENTION_PERIOD:-365}d
-
-chunk_store_config:
-  max_look_back_period: 0s
+  allow_structured_metadata: false # this can be removed after 2025-05-09
+  volume_enabled: true
 
 ruler:
   storage:

--- a/imageroot/scripts/expandconfig-traefik
+++ b/imageroot/scripts/expandconfig-traefik
@@ -26,7 +26,7 @@ cat >traefik.yaml <<EOF
 http:
   routers:
     loki-log-ingress:
-      rule: "Path(\`/loki/api/v1/push\`) && Headers(\`Authorization\`, \`Bearer ${LOKI_LOGS_INGRESS_TOKEN}\`)"
+      rule: "Path(\`/loki/api/v1/push\`) && Header(\`Authorization\`, \`Bearer ${LOKI_LOGS_INGRESS_TOKEN}\`)"
       service: loki
     loki-api:
       rule: "PathPrefix(\`/\`)"

--- a/imageroot/systemd/user/loki-server.service
+++ b/imageroot/systemd/user/loki-server.service
@@ -19,6 +19,8 @@ ExecStart=/usr/bin/podman run \
     --volume=loki-server-data:/loki \
     --volume=%S/loki-config.yaml:/etc/loki/local-config.yaml:Z \
     --env=LOKI_RETENTION_PERIOD \
+    --env=LOKI_ALLOW_STRUCTURED_METADATA \
+    --env=LOKI_V13_SCHEMA_START \
     ${LOKI_IMAGE} \
     -config.file=/etc/loki/local-config.yaml \
     -log.level=warn \

--- a/imageroot/update-module.d/10config
+++ b/imageroot/update-module.d/10config
@@ -24,3 +24,8 @@ if os.getenv('CLOUD_LOG_MANAGER_UUID') is None:
     clm_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, rdb.get('cluster/uuid') or str(uuid.uuid4())))
     agent.set_env('CLOUD_LOG_MANAGER_UUID', clm_uuid)
     agent.set_env('CLOUD_LOG_MANAGER_HOSTNAME', 'cluster-' + clm_uuid[:8])
+
+if os.getenv('LOKI_V13_SCHEMA_START') is None:
+    # Set the default value for LOKI_V13_SCHEMA_START, which is the day after the current date
+    agent.set_env('LOKI_V13_SCHEMA_START', (datetime.date.today() + datetime.timedelta(days=1)).isoformat())
+    agent.set_env('LOKI_ALLOW_STRUCTURED_METADATA', 'false') # this could be manually set to true after LOKI_V13_SCHEMA_START date


### PR DESCRIPTION
Changes:
- bump Loki release
- fix configuration for Loki v3: use a variable date to enable schema v13
- bump Traefik release
- fix configuration for Traefik v3

To update an existing installation:
```
api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/loki:issue7273","instances":["loki1"]}'
```

For a clean install:
```
curl https://raw.githubusercontent.com/NethServer/ns8-core/main/core/install.sh > install.sh 
bash install.sh ghcr.io/nethserver/loki:issue7273
create-cluster rl1.leader.cluster0.gs.nethserver.net:55820 10.5.4.0/24 Nethesis,1234
```

NethServer/dev#7273

Tested also with new Alloy client that is going to replace promtaiò: https://github.com/NethServer/ns8-core/pull/854