### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/cloud-log-manager-forwarder.service
+++ b/imageroot/systemd/user/cloud-log-manager-forwarder.service
@@ -5,7 +5,7 @@ After=loki-server.service
 
 [Service]
 Restart=always
-ExecStart=runagent %S/bin/cloud-log-manager-forwarder
+ExecStart=runagent %E/bin/cloud-log-manager-forwarder
 
 [Install]
 WantedBy=default.target

--- a/imageroot/systemd/user/loki-server.service
+++ b/imageroot/systemd/user/loki-server.service
@@ -5,7 +5,7 @@ After=loki.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 ExecStartPre=/bin/rm -f %t/loki-server.pid %t/loki-server.ctr-id
 ExecStart=/usr/bin/podman run \
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/podman run \
     --replace \
     --name=%N \
     --volume=loki-server-data:/loki \
-    --volume=%S/loki-config.yaml:/etc/loki/local-config.yaml:Z \
+    --volume=%E/loki-config.yaml:/etc/loki/local-config.yaml:Z \
     --env=LOKI_RETENTION_PERIOD \
     --env=LOKI_ALLOW_STRUCTURED_METADATA \
     --env=LOKI_V13_SCHEMA_START \
@@ -30,7 +30,7 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/loki-server.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/loki-server.ctr-id
 PIDFile=%t/loki-server.pid
 Type=forking
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 
 [Install]
 WantedBy=default.target

--- a/imageroot/systemd/user/loki.service
+++ b/imageroot/systemd/user/loki.service
@@ -5,7 +5,7 @@ Before=loki-server.service traefik.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/loki.pid %t/loki.pod-id

--- a/imageroot/systemd/user/syslog-forwarder.service
+++ b/imageroot/systemd/user/syslog-forwarder.service
@@ -5,7 +5,7 @@ After=loki-server.service
 
 [Service]
 Restart=always
-ExecStart=runagent %S/bin/syslog-forwarder
+ExecStart=runagent %E/bin/syslog-forwarder
 
 [Install]
 WantedBy=default.target

--- a/imageroot/systemd/user/traefik.service
+++ b/imageroot/systemd/user/traefik.service
@@ -5,10 +5,10 @@ After=loki.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 ExecStartPre=/bin/rm -f %t/traefik.pid %t/traefik.ctr-id
-ExecStartPre=%S/scripts/expandconfig-traefik
+ExecStartPre=%E/scripts/expandconfig-traefik
 ExecStart=/usr/bin/podman run \
     --detach \
     --conmon-pidfile=%t/traefik.pid \
@@ -25,7 +25,7 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/traefik.ctr-id
 PIDFile=%t/traefik.pid
 Type=forking
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host